### PR TITLE
34 sharedoptions to options should throw exception

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,8 @@ Release 1.0.1
 =========================================
 
 * **BUGFIX**: Fixed a bug encountered when parsing CSV data (issue #32).
+* **ENHANCEMENT**: Added a catch for when trying to set ``Chart.options`` to a ``SharedOptions`` instance (issue #34).
+* Fixed a broken link in the documentation.
 
 ---------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -337,9 +337,9 @@ Core Components
       :class:`SolidGaugeOptions <highcharts_core.options.plot_options.gauge.SolidGaugeOptions>`
   * - :mod:`.options.plot_options.generic <highcharts_core.options.plot_options.generic>`
     - :class:`GenericTypeOptions <highcharts_core.options.plot_options.generic.GenericTypeOptions>`
-  * - :mod:`.options.plot_options.Heatmap <highcharts_core.options.plot_options.Heatmap>`
-    - :class:`HeatmapOptions <highcharts_core.options.plot_options.Heatmap.HeatmapOptions>`
-      :class:`TilemapOptions <highcharts_core.options.plot_options.Tilemap.TilemapOptions>`
+  * - :mod:`.options.plot_options.heatmap <highcharts_core.options.plot_options.heatmap>`
+    - :class:`HeatmapOptions <highcharts_core.options.plot_options.heatmap.HeatmapOptions>`
+      :class:`TilemapOptions <highcharts_core.options.plot_options.heatmap.TilemapOptions>`
   * - :mod:`.options.plot_options.histogram <highcharts_core.options.plot_options.histogram>`
     - :class:`HistogramOptions <highcharts_core.options.plot_options.histogram.HistogramOptions>`
   * - :mod:`.options.plot_options.item <highcharts_core.options.plot_options.item>`

--- a/docs/api/options/index.rst
+++ b/docs/api/options/index.rst
@@ -265,9 +265,9 @@ Sub-components
       :class:`SolidGaugeOptions <highcharts_core.options.plot_options.gauge.SolidGaugeOptions>`
   * - :mod:`.options.plot_options.generic <highcharts_core.options.plot_options.generic>`
     - :class:`GenericTypeOptions <highcharts_core.options.plot_options.generic.GenericTypeOptions>`
-  * - :mod:`.options.plot_options.Heatmap <highcharts_core.options.plot_options.Heatmap>`
-    - :class:`HeatmapOptions <highcharts_core.options.plot_options.Heatmap.HeatmapOptions>`
-      :class:`TilemapOptions <highcharts_core.options.plot_options.Tilemap.TilemapOptions>`
+  * - :mod:`.options.plot_options.heatmap <highcharts_core.options.plot_options.heatmap>`
+    - :class:`HeatmapOptions <highcharts_core.options.plot_options.heatmap.HeatmapOptions>`
+      :class:`TilemapOptions <highcharts_core.options.plot_options.heatmap.TilemapOptions>`
   * - :mod:`.options.plot_options.histogram <highcharts_core.options.plot_options.histogram>`
     - :class:`HistogramOptions <highcharts_core.options.plot_options.histogram.HistogramOptions>`
   * - :mod:`.options.plot_options.item <highcharts_core.options.plot_options.item>`

--- a/docs/api/options/plot_options/index.rst
+++ b/docs/api/options/plot_options/index.rst
@@ -139,9 +139,9 @@ Sub-components
       :class:`SolidGaugeOptions <highcharts_core.options.plot_options.gauge.SolidGaugeOptions>`
   * - :mod:`.options.plot_options.generic <highcharts_core.options.plot_options.generic>`
     - :class:`GenericTypeOptions <highcharts_core.options.plot_options.generic.GenericTypeOptions>`
-  * - :mod:`.options.plot_options.Heatmap <highcharts_core.options.plot_options.Heatmap>`
-    - :class:`HeatmapOptions <highcharts_core.options.plot_options.Heatmap.HeatmapOptions>`
-      :class:`TilemapOptions <highcharts_core.options.plot_options.Tilemap.TilemapOptions>`
+  * - :mod:`.options.plot_options.heatmap <highcharts_core.options.plot_options.heatmap>`
+    - :class:`HeatmapOptions <highcharts_core.options.plot_options.heatmap.HeatmapOptions>`
+      :class:`TilemapOptions <highcharts_core.options.plot_options.heatmap.TilemapOptions>`
   * - :mod:`.options.plot_options.histogram <highcharts_core.options.plot_options.histogram>`
     - :class:`HistogramOptions <highcharts_core.options.plot_options.histogram.HistogramOptions>`
   * - :mod:`.options.plot_options.item <highcharts_core.options.plot_options.item>`

--- a/highcharts_core/chart.py
+++ b/highcharts_core/chart.py
@@ -185,8 +185,18 @@ class Chart(HighchartsMeta):
         return self._options
 
     @options.setter
-    @class_sensitive(HighchartsOptions)
     def options(self, value):
+        if not value:
+            self._options = None
+        elif isinstance(value, SharedOptions):
+            raise errors.HighchartsValueError('Chart.options expects a HighchartsOptions instance '
+                                              'or a valid descendent. However, the value you supplied '
+                                              'is a SharedOptions instance, which wil a descendent is not '
+                                              'valid for this parameter.')
+        else:
+            value = validate_types(value,
+                                   types = HighchartsOptions)
+
         self._options = value
 
     @property

--- a/highcharts_core/options/series/base.py
+++ b/highcharts_core/options/series/base.py
@@ -440,12 +440,6 @@ class SeriesBase(SeriesOptions):
         except AttributeError:
             pass
 
-        if checkers.is_on_filesystem(as_string_or_file):
-            with open(as_string_or_file, 'r') as file_:
-                as_str = file_.read()
-        else:
-            as_str = as_string_or_file
-
         property_column_map = validators.dict(property_column_map, allow_empty = False)
         cleaned_column_map = {}
         for key in property_column_map:
@@ -464,17 +458,32 @@ class SeriesBase(SeriesOptions):
                                                                f'instead.')
             cleaned_column_map[key] = map_value
 
-        columns, csv_records = utility_functions.parse_csv(
-            as_str,
-            has_header_row = has_header_row,
-            delimiter = delimiter,
-            null_text = null_text,
-            wrapper_character = wrapper_character,
-            line_terminator = line_terminator,
-            wrap_all_strings = False,
-            double_wrapper_character_when_nested = False,
-            escape_character = "\\"
-        )
+        if not checkers.is_on_filesystem(as_string_or_file):
+            as_str = as_string_or_file
+            columns, csv_records = utility_functions.parse_csv(
+                as_str,
+                has_header_row = has_header_row,
+                delimiter = delimiter,
+                null_text = null_text,
+                wrapper_character = wrapper_character,
+                line_terminator = line_terminator,
+                wrap_all_strings = False,
+                double_wrapper_character_when_nested = False,
+                escape_character = "\\"
+            )
+        else:
+            with open(as_string_or_file, 'r', newline = '') as file_:
+                columns, csv_records = utility_functions.parse_csv(
+                    file_,
+                    has_header_row = has_header_row,
+                    delimiter = delimiter,
+                    null_text = null_text,
+                    wrapper_character = wrapper_character,
+                    line_terminator = line_terminator,
+                    wrap_all_strings = False,
+                    double_wrapper_character_when_nested = False,
+                    escape_character = "\\"
+                )
 
         for key in cleaned_column_map:
             map_value = cleaned_column_map[key]
@@ -495,7 +504,14 @@ class SeriesBase(SeriesOptions):
             data_point_dict = {}
             for key in cleaned_column_map:
                 map_value = cleaned_column_map[key]
-                data_point_dict[key] = record.get(map_value, None)
+                value = record.get(map_value, None)
+                if value and isinstance(value, str) and ',' in value:
+                    test_value = value.replace(delimiter, '')
+                    if checkers.is_numeric(test_value):
+                        value = test_value
+
+                data_point_dict[key] = value
+                
             data_point_dicts.append(data_point_dict)
 
         self.data = data_point_dicts
@@ -650,14 +666,14 @@ class SeriesBase(SeriesOptions):
         instance = cls(**series_kwargs)
         instance.load_from_csv(as_string_or_file,
                                property_column_map,
-                               has_header_row = True,
-                               delimiter = ',',
-                               null_text = 'None',
-                               wrapper_character = "'",
-                               line_terminator = '\r\n',
-                               wrap_all_strings = False,
-                               double_wrapper_character_when_nested = False,
-                               escape_character = "\\")
+                               has_header_row = has_header_row,
+                               delimiter = delimiter,
+                               null_text = null_text,
+                               wrapper_character = wrapper_character,
+                               line_terminator = line_terminator,
+                               wrap_all_strings = wrap_all_strings,
+                               double_wrapper_character_when_nested = double_wrapper_character_when_nested,
+                               escape_character = escape_character)
 
         return instance
 

--- a/highcharts_core/utility_functions.py
+++ b/highcharts_core/utility_functions.py
@@ -279,11 +279,11 @@ def parse_csv(csv_data,
     :rtype: :class:`tuple <python:tuple>` of a :class:`list <python:list>` of column names
       and :class:`list <python:list>` of :class:`dict <python:dict>`
     """
-    csv_data = validators.string(csv_data, allow_empty = True)
     if not csv_data:
         return [], []
 
-    csv_data = csv_data.split(line_terminator)
+    if isinstance(csv_data, str):
+        csv_data = csv_data.split(line_terminator)
 
     if not wrapper_character:
         wrapper_character = "'"

--- a/tests/options/series/test_area.py
+++ b/tests/options/series/test_area.py
@@ -2789,6 +2789,41 @@ def test_bugfix32_LineSeries_from_csv(kwargs, error):
             assert item.x is not None
             assert item.y is not None
 
+
+@pytest.mark.parametrize('filename, property_map, kwargs, error', [
+    ('test-data-files/nst-est2019-01.csv', {}, {}, ValueError),
+    ('test-data-files/nst-est2019-01.csv',
+     {
+         'name': 'Geographic Area',
+         'x': 'Geographic Area',
+         'y': '2010'
+     },
+     {
+         'wrapper_character': '"'
+     },
+     None),
+
+])
+def test_LineSeries_from_csv(input_files, filename, property_map, kwargs, error):
+    input_file = check_input_file(input_files, filename)
+    
+    if not error:
+        result = cls5.from_csv(input_file,
+                               property_column_map = property_map,
+                               **kwargs)
+        assert result is not None
+        assert isinstance(result, cls5)
+        assert result.data is not None
+        for item in result.data:
+            for key in property_map:
+                assert getattr(item, key, None) is not None
+    else:
+        with pytest.raises(error):
+            result = cls5.from_csv(input_file, 
+                                   property_column_map = property_map,
+                                   **kwargs)
+
+
 #### NEXT CLASS
 
 @pytest.mark.parametrize('kwargs, error', STANDARD_PARAMS)

--- a/tests/test_chart.py
+++ b/tests/test_chart.py
@@ -5,6 +5,7 @@ import pytest
 from json.decoder import JSONDecodeError
 
 from highcharts_core.chart import Chart as cls
+from highcharts_core.global_options.shared_options import SharedOptions
 from highcharts_core import errors
 from tests.fixtures import input_files, check_input_file, to_camelCase, to_js_dict, \
     Class__init__, Class__to_untrimmed_dict, Class_from_dict, Class_to_dict, \
@@ -18,6 +19,19 @@ STANDARD_PARAMS = [
 @pytest.mark.parametrize('kwargs, error', STANDARD_PARAMS)
 def test__init__(kwargs, error):
     Class__init__(cls, kwargs, error)
+
+
+@pytest.mark.parametrize('kwargs, error', [
+    ({}, errors.HighchartsValueError),
+])
+def test_bugfix34_SharedOptions_error(kwargs, error):
+    shared_options = SharedOptions()
+    instance = cls(**kwargs)
+    if not error:
+        instance.options = shared_options
+    else:
+        with pytest.raises(error):
+            instance.options = shared_options
 
 
 @pytest.mark.parametrize('kwargs, error', STANDARD_PARAMS)


### PR DESCRIPTION
* **ENHANCEMENT**: Added a catch for when trying to set ``Chart.options`` to a ``SharedOptions`` instance (closes #34).
* Fixed a broken link in the documentation.