### PR TITLE
Fixed: jupyter-notebook display

### DIFF
--- a/highcharts_core/chart.py
+++ b/highcharts_core/chart.py
@@ -727,7 +727,7 @@ class Chart(HighchartsMeta):
         """
         try:
             from IPython import display as display_mod
-            from IPython.core.display_functions import display
+            from IPython.display import display
         except ImportError:
             raise errors.HighchartsDependencyError('Unable to import IPython modules. '
                                                    'Make sure that it is available in '


### PR DESCRIPTION
Fixed the ModuleNotFoundError: No module named 'IPython.core.display_functions' for me.

Environment: google colab, Python==3.10, IPython==7.34.0

![image](https://github.com/highcharts-for-python/highcharts-core/assets/60819389/535b8761-0857-4e59-9a2f-2981e6ec5ca7)
